### PR TITLE
Add item class

### DIFF
--- a/classes/item.rb
+++ b/classes/item.rb
@@ -1,0 +1,16 @@
+require 'securerandom'
+
+class Item
+  attr_accessor :genre, :author, :source, :label, :publish_date
+  attr_reader :id, :archived
+
+  def initialize(date)
+    @id = SecureRandom.uuid
+    @genre = genre
+    @author = author
+    @source = source
+    @label = label
+    @publish_date = date
+    @archived = archived
+  end
+end

--- a/classes/item.rb
+++ b/classes/item.rb
@@ -1,10 +1,11 @@
 require 'securerandom'
+require 'date'
 
 class Item
   attr_accessor :genre, :author, :source, :label, :publish_date
   attr_reader :id, :archived
 
-  def initialize(date)
+  def initialize(date, archived: false)
     @id = SecureRandom.uuid
     @genre = genre
     @author = author
@@ -12,5 +13,19 @@ class Item
     @label = label
     @publish_date = date
     @archived = archived
+  end
+
+  def can_be_archived?
+    now = Date.today
+    date_array = @publish_date.split(/-/)
+    p_date = Date.civil(date_array[0].to_i, date_array[1].to_i, date_array[2].to_i)
+    difference_in_days = (now - p_date).to_i
+    years = (difference_in_days/365.25).to_i
+
+    years >= 10
+  end
+
+  def move_to_archive
+    @archived = true if can_be_archived?
   end
 end

--- a/classes/item.rb
+++ b/classes/item.rb
@@ -15,12 +15,32 @@ class Item
     @archived = archived
   end
 
+  def add_genre=(genre)
+    @genre = genre
+    genre.items.push(self) unless genre.items.include?(self)
+  end
+
+  def add_author=(author)
+    @author = author
+    author.items.push(self) unless author.items.include?(self)
+  end
+
+  def add_source=(source)
+    @source = source
+    source.items.push(self) unless source.items.include?(self)
+  end
+
+  def add_label=(label)
+    @label = label
+    label.items.push(self) unless label.items.include?(self)
+  end
+
   def can_be_archived?
     now = Date.today
     date_array = @publish_date.split(/-/)
     p_date = Date.civil(date_array[0].to_i, date_array[1].to_i, date_array[2].to_i)
     difference_in_days = (now - p_date).to_i
-    years = (difference_in_days/365.25).to_i
+    years = (difference_in_days / 365.25).to_i
 
     years >= 10
   end

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,11 @@
+require_relative './classes/item'
+
+item1 = Item.new('2022-10-20')
+p item1
+item2 = Item.new('2012-10-20')
+p item2
+
+item1.move_to_archive
+puts item1.archived
+item2.move_to_archive
+puts item2.archived


### PR DESCRIPTION
- [x]  All Item class properties visible in the diagram should be defined and set up in the constructor method. Exception: properties for the 1-to-many relationships should NOT be set in the constructor method. Instead, they should have a custom setter method created. 

- [x] Add all methods visible in the diagram. 

- [x] Implement methods:
  - can_be_archived?() in the Item class
    - should return true if published_date is older than 10 years
    - otherwise, it should return false
  - move_to_archive() in the Item class
    - should reuse can_be_archived?() method
    - should change the archived property to true if the result of the can_be_archived?() method is true
    - should do nothing if the result of the can_be_archived?() method is false